### PR TITLE
refactored router paging and added prop passing

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,52 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_locker/flutter_locker.dart';
 import 'package:suiinvest/src/frontend/routing.dart';
 
 import 'services/sui_example.dart';
-
-Future<void> canAuthenticate() async {
-  try {
-    final canAuthenticate = await FlutterLocker.canAuthenticate();
-
-    print('Can authenticate: $canAuthenticate');
-  } on Exception catch (exception) {
-    print(exception);
-  }
-}
-
-Future<void> saveSecret(key, secret) async {
-  try {
-    await FlutterLocker.save(
-      SaveSecretRequest(
-          key: key,
-          secret: secret,
-          androidPrompt: AndroidPrompt(
-              title: 'Authenticate',
-              cancelLabel: 'Cancel',
-              descriptionLabel: 'Please authenticate')),
-    );
-
-    print('Secret saved, secret: $secret');
-  } on Exception catch (exception) {
-    print(exception);
-  }
-}
-
-Future<void> retrieveSecret(key) async {
-  try {
-    final retrieved = await FlutterLocker.retrieve(RetrieveSecretRequest(
-        key: key,
-        androidPrompt: AndroidPrompt(
-            title: 'Authenticate',
-            cancelLabel: 'Cancel',
-            descriptionLabel: 'Please authenticate'),
-        iOsPrompt: IOsPrompt(touchIdText: 'Authenticate')));
-
-    print('Secret retrieved, secret: $retrieved');
-  } on Exception catch (exception) {
-    print(exception);
-  }
-}
 
 /// The Widget that configures your application.
 class MyApp extends StatelessWidget {

--- a/lib/src/frontend/common/helpers/string.dart
+++ b/lib/src/frontend/common/helpers/string.dart
@@ -1,0 +1,3 @@
+String trimUserAddress(String address, int lengthPre, int lengthPost) {
+  return (address.substring(0, lengthPre) + '...' + address.substring(address.length - lengthPost, address.length));
+}

--- a/lib/src/frontend/home.dart
+++ b/lib/src/frontend/home.dart
@@ -1,6 +1,12 @@
 import 'package:flutter/material.dart';
-
+import 'package:sui/sui.dart';
+import 'package:suiinvest/src/frontend/common/helpers/string.dart';
 class HomePage extends StatelessWidget {
+  // props
+  final SuiAccount userAccount;
+  //constructor
+  HomePage({required this.userAccount});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -13,7 +19,7 @@ class HomePage extends StatelessWidget {
               padding:
                   const EdgeInsets.only(top: 70.0, left: 16.0, right: 16.0),
               children: [
-                Welcome(context),
+                Welcome(context, userAccount),
                 SizedBox(height: 30.0),
                 buildPortfolio(context),
                 SizedBox(height: 40.0),
@@ -78,7 +84,7 @@ class HomePage extends StatelessWidget {
   }
 }
 
-Widget Welcome(BuildContext context) {
+Widget Welcome(BuildContext context, SuiAccount userAccount) {
   return Container(
     padding: EdgeInsets.all(16.0),
     child: Column(
@@ -103,7 +109,7 @@ Widget Welcome(BuildContext context) {
               ),
             ),
             Text(
-              '0x23...ed',
+              trimUserAddress(userAccount.getAddress(), 6, 3),
               style: TextStyle(
                 color: Colors.grey[300],
                 fontSize: 16.0,

--- a/lib/src/services/authentication.dart
+++ b/lib/src/services/authentication.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_locker/flutter_locker.dart';
+import 'package:suiinvest/src/services/sui_example.dart';
+import 'package:sui/sui.dart';
+
+// return type is bool of if device can authenticate
+Future<bool> canAuthenticate() async {
+  try {
+    final canAuthenticate = await FlutterLocker.canAuthenticate();
+
+    print('Can authenticate: $canAuthenticate');
+    return canAuthenticate ?? false;
+  } on Exception catch (exception) {
+    print(exception);
+    return false;
+  }
+}
+
+// return type is bool of success when we store a key -> secret pair
+Future<bool> saveSecret(key, secret) async {
+  try {
+    await FlutterLocker.save(
+      SaveSecretRequest(
+          key: key,
+          secret: secret,
+          androidPrompt: AndroidPrompt(
+              title: 'Authenticate',
+              cancelLabel: 'Cancel',
+              descriptionLabel: 'Please authenticate')),
+    );
+
+    print('Secret saved, secret: $secret');
+    return true;
+  } on Exception catch (exception) {
+    print(exception);
+    return false;
+  }
+}
+
+// return type is string of secret when we fetch via key, or null if key not found
+Future<String> retrieveSecret(key) async {
+  try {
+    final retrieved = await FlutterLocker.retrieve(RetrieveSecretRequest(
+        key: key,
+        androidPrompt: AndroidPrompt(
+            title: 'Authenticate',
+            cancelLabel: 'Cancel',
+            descriptionLabel: 'Please authenticate'),
+        iOsPrompt: IOsPrompt(touchIdText: 'Authenticate')));
+
+    print('Secret retrieved, secret: $retrieved');
+    return retrieved;
+  } on Exception catch (exception) {
+    print(exception);
+    return "";
+  }
+}
+
+
+// fetches user account from keystore and constructs a SuiAccount object
+Future<SuiAccount?> fetchUserAccount() async {
+  try {
+    final privKey = await retrieveSecret("private_key");
+    return buildUserFromPrivKey(privKey);
+  } on Exception catch (exception) {
+    print(exception);
+    return null;
+  }
+}

--- a/lib/src/services/sui_example.dart
+++ b/lib/src/services/sui_example.dart
@@ -3,6 +3,17 @@ import 'package:sui/sui.dart';
 import 'package:sui/cryptography/signature.dart';
 import 'package:flutter_config/flutter_config.dart';
 
+// return type is bool of success when we store a key -> secret pair
+Future<SuiAccount?> buildUserFromPrivKey(privateKey) async {
+  try {
+    late SuiAccount account = SuiAccount.fromPrivateKey(privateKey, SignatureScheme.ED25519);
+    return account;
+  } on Exception catch (exception) {
+    print(exception);
+    return null;
+  }
+}
+
 class SuiTest extends StatefulWidget {
   const SuiTest({Key? key, required this.title}): super(key: key);
 


### PR DESCRIPTION
refactored router with new design where we don't preload pages and use a list to fetch, instead we load dynamically to allow us to properly pass async props through

added dynamic fetching of account details from user priv key store in .env file